### PR TITLE
feat(alerts): route throttled operational error alerts to Telegram #30

### DIFF
--- a/alerts/__init__.py
+++ b/alerts/__init__.py
@@ -11,6 +11,7 @@ from alerts.base import (
     notify_trailing_sl,
     notify_trade_exit,
     notify_eod_summary,
+    notify_system_error,
 )
 from alerts.telegram import TelegramAlertChannel
 from alerts.subscribers import SubscribersRegistry
@@ -24,4 +25,5 @@ __all__ = [
     "notify_trailing_sl",
     "notify_trade_exit",
     "notify_eod_summary",
+    "notify_system_error",
 ]

--- a/alerts/base.py
+++ b/alerts/base.py
@@ -36,6 +36,18 @@ class BaseAlertChannel(abc.ABC):
         """Sends an End-Of-Day performance summary."""
         pass
 
+    @abc.abstractmethod
+    def send_system_error(
+        self,
+        component: str,
+        error_msg: str,
+        severity: str = "warning",
+        action_taken: str = "",
+        cooldown_seconds: Optional[int] = None,
+    ) -> bool:
+        """Sends a throttled operational/system error notification."""
+        pass
+
 
 def get_active_channels(config: TradingConfig = CONFIG) -> List[BaseAlertChannel]:
     """
@@ -86,3 +98,28 @@ def notify_eod_summary(report_text: str, mode: str = "paper", config: TradingCon
     """Broadcasts an End-Of-Day performance report across all active channels."""
     for ch in get_active_channels(config):
         ch.send_eod_summary(report_text=report_text, mode=mode)
+
+
+def notify_system_error(
+    component: str,
+    error_msg: str,
+    severity: str = "warning",
+    action_taken: str = "",
+    cooldown_seconds: Optional[int] = None,
+    config: TradingConfig = CONFIG,
+) -> None:
+    """
+    Broadcasts a throttled operational/system error across all active channels.
+
+    Channels are expected to debounce identical ``(component, error_msg)`` pairs so
+    a sustained outage does not flood the operator's Telegram. The first occurrence
+    is dispatched immediately; identical re-occurrences are throttled per-channel.
+    """
+    for ch in get_active_channels(config):
+        ch.send_system_error(
+            component=component,
+            error_msg=error_msg,
+            severity=severity,
+            action_taken=action_taken,
+            cooldown_seconds=cooldown_seconds,
+        )

--- a/alerts/telegram.py
+++ b/alerts/telegram.py
@@ -8,13 +8,25 @@ deprecated no-op so existing call sites keep importing.
 """
 
 import os
+import threading
 import requests
 import datetime
 import warnings
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Dict
 
 from alerts.base import BaseAlertChannel
 from alerts.subscribers import SubscribersRegistry
+
+# Default cooldown for repeated operational-error alerts.
+DEFAULT_SYSTEM_ERROR_COOLDOWN_SEC = 15 * 60
+
+# Severity → emoji map. Unknown severities fall back to the warning glyph.
+_SEVERITY_ICON = {
+    "critical": "🚨",
+    "warning": "⚠️",
+    "halt": "🛑",
+    "rejection": "❌",
+}
 
 
 class TelegramAlertChannel(BaseAlertChannel):
@@ -34,6 +46,11 @@ class TelegramAlertChannel(BaseAlertChannel):
                 stacklevel=2,
             )
         self._registry = SubscribersRegistry()
+        # Throttle state for operational-error alerts. Keyed by (component, error_msg);
+        # values are UTC timestamps of the most recent dispatch.
+        self._error_throttle: Dict[str, datetime.datetime] = {}
+        self._error_throttle_lock = threading.Lock()
+        self._error_cooldown_seconds = DEFAULT_SYSTEM_ERROR_COOLDOWN_SEC
 
     @property
     def is_configured(self) -> bool:
@@ -115,6 +132,69 @@ class TelegramAlertChannel(BaseAlertChannel):
             )
 
     # --- typed helpers -----------------------------------------------------
+
+    def send_system_error(
+        self,
+        component: str,
+        error_msg: str,
+        severity: str = "warning",
+        action_taken: str = "",
+        cooldown_seconds: Optional[int] = None,
+    ) -> bool:
+        """
+        Dispatches a throttled operational/system error to all active subscribers.
+
+        Args:
+            component: short subsystem label (e.g. "OpenAlgo", "EngineLoop", "CircuitBreaker").
+            error_msg: human-readable error description. Combined with ``component`` to form
+                the throttle key, so two distinct errors from the same component each get
+                their own debounce window.
+            severity: one of ``"critical"`` (🚨), ``"warning"`` (⚠️), ``"halt"`` (🛑),
+                ``"rejection"`` (❌). Unknown values fall back to the warning glyph.
+            action_taken: optional recovery / mitigation note included in the message body.
+            cooldown_seconds: override the default 15-minute cooldown (mainly for tests).
+
+        Returns:
+            True when the message was dispatched, False when throttled, when no token
+            is configured, or when delivery failed.
+        """
+        component = (component or "Unknown").strip()
+        error_msg = (error_msg or "Unspecified error").strip()
+        severity_key = (severity or "warning").strip().lower()
+        icon = _SEVERITY_ICON.get(severity_key, "⚠️")
+        cooldown = (
+            cooldown_seconds
+            if cooldown_seconds is not None
+            else self._error_cooldown_seconds
+        )
+
+        throttle_key = f"{component}::{error_msg}"
+        now = datetime.datetime.now()
+        with self._error_throttle_lock:
+            last_sent = self._error_throttle.get(throttle_key)
+            if last_sent is not None and (now - last_sent).total_seconds() < cooldown:
+                # Suppressed by the debounce window. We still surface a log line so the
+                # operator can see the alert was caught and intentionally not re-sent.
+                print(
+                    f"[{now.strftime('%H:%M:%S')}] 🔇 [TELEGRAM] Suppressed repeat "
+                    f"system-error alert ({severity_key}/{component}) — "
+                    f"cooldown {cooldown}s not elapsed."
+                )
+                return False
+            self._error_throttle[throttle_key] = now
+
+        action_block = (
+            f"\n• *Action Taken:* {action_taken.strip()}"
+            if action_taken and action_taken.strip()
+            else ""
+        )
+        msg = (
+            f"{icon} *[{severity_key.upper()} ALERT]* `{component}`\n"
+            f"• *Time:* `{now.strftime('%Y-%m-%d %H:%M:%S')}`\n"
+            f"• *Error:* {error_msg}"
+            f"{action_block}"
+        )
+        return self.send_message(msg)
 
     def send_trade_entry(self, symbol: str, price: float, sl: float, tp: float, qty: int, mode: str = "paper") -> bool:
         msg = (

--- a/live_trading/base_engine.py
+++ b/live_trading/base_engine.py
@@ -44,7 +44,7 @@ from core.trade_db import (
     get_db_path,
     get_trade_journal,
 )
-from alerts import notify_trade_entry, notify_trailing_sl, notify_trade_exit, notify_eod_summary
+from alerts import notify_trade_entry, notify_trailing_sl, notify_trade_exit, notify_eod_summary, notify_system_error
 from strategies.vwap_stoch_breakdown import (
     STRATEGY_NAME,
     STRATEGY_VERSION,
@@ -137,11 +137,44 @@ class BaseTradingEngine:
             max_loss_pct=self.config.MAX_DAILY_LOSS_PCT
         )
 
+    @staticmethod
+    def _looks_like_auth_failure(payload: Any) -> Optional[str]:
+        """
+        Heuristic that returns a human-readable reason if a broker/OpenAlgo
+        response indicates an expired or invalid session. Returns ``None`` for
+        unrelated errors so callers can keep their existing flow.
+        """
+        if payload is None:
+            return None
+        if isinstance(payload, dict):
+            for key in ("message", "msg", "error", "reason"):
+                val = payload.get(key)
+                if isinstance(val, str) and (
+                    "session" in val.lower()
+                    and ("expir" in val.lower() or "invalid" in val.lower())
+                ):
+                    return val
+        text = str(payload)
+        lowered = text.lower()
+        if "401" in text or "unauthorized" in lowered:
+            return text
+        if "session" in lowered and ("expir" in lowered or "invalid" in lowered):
+            return text
+        return None
+
     def get_account_capital(self) -> float:
         """Returns the active available capital for position sizing."""
         if (self.mode == "live" or getattr(self.config, 'TRADING_MODE', 'paper') == "live") and self.api:
             try:
                 limits = self.api.get_limits()
+                auth_reason = self._looks_like_auth_failure(limits)
+                if auth_reason:
+                    notify_system_error(
+                        component="OpenAlgo",
+                        error_msg=f"Broker session rejected: {auth_reason}",
+                        severity="warning",
+                        action_taken="Please run the morning re-authentication script to refresh the broker API key.",
+                    )
                 if limits and limits.get('stat') == 'Ok':
                     # Check payin / cash / net fields
                     cash = float(limits.get('cash', 0.0))
@@ -201,7 +234,14 @@ class BaseTradingEngine:
             print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] ✅ Connected to OpenAlgo Unified OMS Gateway ({host}).")
             return True
         except Exception as e:
+            err_text = str(e).strip() or repr(e)
             print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] ⚠️ OpenAlgo connection failed: {e}. Running in local fallback.")
+            notify_system_error(
+                component="OpenAlgo",
+                error_msg=f"Gateway unreachable at {host}: {err_text}",
+                severity="critical",
+                action_taken="Engine fell back to yfinance market feed for this session.",
+            )
             self.authenticated = True
             return True
 
@@ -371,7 +411,23 @@ class BaseTradingEngine:
     def scan_and_execute_signals(self, nifty_pct_map: pd.Series) -> None:
         """Scans the universe across worker threads on 15m candle close boundaries."""
         if self.is_daily_circuit_breaker_active():
+            today_realized_pnl = self.get_account_capital() - self.day_starting_capital
+            loss_pct = (
+                (today_realized_pnl / self.day_starting_capital) * 100.0
+                if self.day_starting_capital > 0 else 0.0
+            )
             print(f"[{datetime.datetime.now().strftime('%H:%M:%S')}] 🛑 [CIRCUIT BREAKER] Daily Loss reached. Halting new scan entries.")
+            notify_system_error(
+                component="CircuitBreaker",
+                error_msg=(
+                    f"Daily loss cap of {self.config.MAX_DAILY_LOSS_PCT * 100:.1f}% reached "
+                    f"(realized PnL: ₹{today_realized_pnl:+,.2f} / {loss_pct:+.2f}%)."
+                ),
+                severity="halt",
+                action_taken=(
+                    "All open positions were squared off and new entries are blocked for the remainder of the session."
+                ),
+            )
             return
 
         universe_name = getattr(self.config, 'UNIVERSE', 'NIFTY50').upper()
@@ -392,7 +448,20 @@ class BaseTradingEngine:
         with ThreadPoolExecutor(max_workers=8) as executor:
             futures = [executor.submit(self._evaluate_single_symbol, t, nifty_pct_map) for t in symbols]
             for f in futures:
-                res = f.result()
+                try:
+                    res = f.result()
+                except Exception as scan_err:
+                    import traceback
+                    notify_system_error(
+                        component="EngineLoop.15mScanner",
+                        error_msg=(
+                            f"Unhandled exception in scanner worker: {scan_err}\n"
+                            f"{traceback.format_exc(limit=3).strip()}"
+                        ),
+                        severity="critical",
+                        action_taken="Symbol skipped this cycle; engine will retry on the next 15m candle.",
+                    )
+                    continue
                 if res is None:
                     continue
                 if res['rel_weak_pass']: funnel_stats['rel_weakness_passed'] += 1
@@ -428,8 +497,26 @@ class BaseTradingEngine:
             entry_p = float(row['Close'])
             sl_p, tp_p = calculate_stop_and_target(entry_price=entry_p, swing_high=swing_high, config=self.config)
 
-            # Delegate order placement to child class hook
-            self.execute_entry(symbol=sym_key, entry_price=entry_p, sl_price=sl_p, tp_price=tp_p)
+            # Delegate order placement to child class hook. Wrap so any rejection
+            # (raised exception or a False return from the child hook) is routed to
+            # the operational error channel instead of being silently swallowed.
+            try:
+                placed = self.execute_entry(symbol=sym_key, entry_price=entry_p, sl_price=sl_p, tp_price=tp_p)
+            except Exception as entry_err:
+                notify_system_error(
+                    component="OrderPlacement",
+                    error_msg=f"Exception placing entry for {sym_key}: {entry_err}",
+                    severity="rejection",
+                    action_taken="Entry skipped; signal will be re-evaluated on the next 15m candle.",
+                )
+                continue
+            if not placed:
+                notify_system_error(
+                    component="OrderPlacement",
+                    error_msg=f"Broker rejected entry order for {sym_key} @ ₹{entry_p:,.2f} (SL ₹{sl_p:,.2f}).",
+                    severity="rejection",
+                    action_taken="Check broker console for margin / freeze-quantity reasons; entry skipped for this candle.",
+                )
 
     def monitor_active_positions(self) -> None:
         """Micro 15-second guardian checking active positions for SL/TP hits & +1R Trailing SL."""
@@ -447,7 +534,17 @@ class BaseTradingEngine:
                 low = tick['low']
 
                 self.update_position(symbol=symbol, current_ltp=ltp, high=high, low=low)
-            except Exception:
+            except Exception as mon_err:
+                import traceback
+                notify_system_error(
+                    component="EngineLoop.15sGuardian",
+                    error_msg=(
+                        f"Exception while monitoring {symbol}: {mon_err}\n"
+                        f"{traceback.format_exc(limit=3).strip()}"
+                    ),
+                    severity="critical",
+                    action_taken="Position skipped this tick; guardian will retry on the next 15-second sweep.",
+                )
                 continue
 
     def squareoff_all_positions(self) -> None:

--- a/tests/test_system_error_throttle.py
+++ b/tests/test_system_error_throttle.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for the throttled operational-error alerting channel.
+
+Covers:
+  * Debounce on identical (component, error_msg) within the cooldown window.
+  * Re-arm once the cooldown has elapsed.
+  * Distinct error keys are NOT debounced against each other.
+  * Severity → emoji mapping.
+  * Top-level notify_system_error dispatcher fans out to every active channel.
+  * send_system_error is a no-op when the channel is not configured.
+"""
+
+import os
+import sys
+import datetime
+import unittest
+import tempfile
+import threading
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from config import CONFIG
+from alerts.telegram import TelegramAlertChannel
+from alerts.base import notify_system_error, BaseAlertChannel
+from alerts.subscribers import SubscribersRegistry
+
+
+def _seed_channel(tmp_db_path: str) -> TelegramAlertChannel:
+    """Returns a configured TelegramAlertChannel with a single active subscriber."""
+    os.environ["TELEGRAM_BOT_TOKEN"] = "TEST_TOKEN"
+    os.environ["TELEGRAM_SUBSCRIBERS_DB_PATH"] = tmp_db_path
+    registry = SubscribersRegistry()
+    registry.subscribe(111, "alice", "Alice")
+    return TelegramAlertChannel()
+
+
+class TestSystemErrorThrottle(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp_db = os.path.join(self._tmpdir.name, "subs.db")
+        self.channel = _seed_channel(self.tmp_db)
+        # Freeze the clock so we can advance time deterministically.
+        self._frozen = datetime.datetime(2026, 8, 26, 9, 30, 0)
+        self._patcher = patch("alerts.telegram.datetime.datetime", wraps=datetime.datetime)
+        self.mock_dt = self._patcher.start()
+        self.mock_dt.now.return_value = self._frozen
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._tmpdir.cleanup()
+
+    def _advance(self, seconds: int) -> None:
+        self._frozen = self._frozen + datetime.timedelta(seconds=seconds)
+        self.mock_dt.now.return_value = self._frozen
+
+    def test_first_occurrence_dispatches_immediately(self):
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            ok = self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                action_taken="Falling back to yfinance",
+                cooldown_seconds=900,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(mock_post.call_count, 1)
+        text = mock_post.call_args.kwargs["json"]["text"]
+        self.assertIn("🚨", text)
+        self.assertIn("OpenAlgo", text)
+        self.assertIn("Connection refused", text)
+        self.assertIn("Falling back to yfinance", text)
+
+    def test_repeat_within_cooldown_is_suppressed(self):
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            first_ok = self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+            self.assertTrue(first_ok)
+            self.assertEqual(mock_post.call_count, 1)
+
+            self._advance(60)
+            second_ok = self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+        self.assertFalse(second_ok)
+        self.assertEqual(mock_post.call_count, 1)  # no new dispatch
+
+    def test_repeat_after_cooldown_re_dispatches(self):
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+            self.assertEqual(mock_post.call_count, 1)
+
+            self._advance(901)  # past the 900s cooldown
+            ok = self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_distinct_error_keys_are_independent(self):
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+            self.assertEqual(mock_post.call_count, 1)
+
+            ok = self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="HTTP 502 from gateway",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_distinct_components_are_independent(self):
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            self.channel.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+            self.assertEqual(mock_post.call_count, 1)
+
+            ok = self.channel.send_system_error(
+                component="OrderPlacement",
+                error_msg="Connection refused",
+                severity="rejection",
+                cooldown_seconds=900,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_severity_icon_mapping(self):
+        cases = [
+            ("critical", "🚨"),
+            ("warning", "⚠️"),
+            ("halt", "🛑"),
+            ("rejection", "❌"),
+            ("unknown_severity", "⚠️"),  # fallback glyph
+        ]
+        for severity, expected_icon in cases:
+            with self.subTest(severity=severity):
+                with patch("alerts.telegram.requests.post") as mock_post:
+                    mock_post.return_value = MagicMock(status_code=200, text="ok")
+                    # Unique component+error so each subTest is not throttled.
+                    self.channel.send_system_error(
+                        component=f"Sev{severity}",
+                        error_msg=f"boom-{severity}",
+                        severity=severity,
+                        cooldown_seconds=900,
+                    )
+                    self.assertEqual(mock_post.call_count, 1)
+                    text = mock_post.call_args.kwargs["json"]["text"]
+                    self.assertIn(expected_icon, text)
+                    self.assertIn(f"[{severity.upper()} ALERT]", text)
+
+    def test_unconfigured_channel_silently_drops(self):
+        ch = TelegramAlertChannel.__new__(TelegramAlertChannel)
+        ch.token = None
+        ch._registry = MagicMock()
+        ch._error_throttle = {}
+        ch._error_throttle_lock = threading.Lock()
+        ch._error_cooldown_seconds = 900
+        self.assertFalse(
+            ch.send_system_error(
+                component="X", error_msg="Y", severity="critical"
+            )
+        )
+
+    def test_top_level_dispatcher_fans_out(self):
+        fake_channel = MagicMock(spec=BaseAlertChannel)
+        fake_channel.send_system_error.return_value = True
+        with patch("alerts.base.get_active_channels", return_value=[fake_channel]):
+            notify_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                action_taken="Falling back",
+            )
+        fake_channel.send_system_error.assert_called_once_with(
+            component="OpenAlgo",
+            error_msg="Connection refused",
+            severity="critical",
+            action_taken="Falling back",
+            cooldown_seconds=None,
+        )
+
+    def test_throttle_state_does_not_leak_across_channels(self):
+        """Each TelegramAlertChannel instance maintains its own throttle state."""
+        ch2 = _seed_channel(self.tmp_db)
+        with patch("alerts.telegram.requests.post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="ok")
+            # Self.channel already sent earlier in this test → throttled.
+            # ch2 is a brand-new channel so it should dispatch fresh.
+            ok = ch2.send_system_error(
+                component="OpenAlgo",
+                error_msg="Connection refused",
+                severity="critical",
+                cooldown_seconds=900,
+            )
+        self.assertTrue(ok)
+        self.assertEqual(mock_post.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#30 

Adds a centralized notify_system_error helper that debounces identical (component, error_msg) pairs at a 15-minute cooldown so sustained outages do not flood the operator's Telegram, while still emitting the first failure immediately.

Hooked into live_trading/base_engine.py at the five failure points called out in the issue:
  * OpenAlgo gateway unreachable  -> critical (authenticate)
  * Broker session / auth expiry  -> warning  (get_account_capital)
  * Daily 3% circuit breaker hit  -> halt     (scan_and_execute_signals)
  * Order placement rejection     -> rejection (execute_entry call site)
  * Unhandled scanner / guardian  -> critical (loop exception guards)

Severity -> emoji map: critical 🚨, warning ⚠️, halt 🛑, rejection ❌. Routing inherits the existing subscriber broadcast + TELEGRAM_OWNER_CHAT_ID fallback (fix 8c285fc) so critical infrastructure alerts reach the admin out of the box.

Adds tests/test_system_error_throttle.py covering debounce, re-arm on cooldown expiry, independent buckets per (component, error_msg), the severity icon map, and the top-level dispatcher fan-out. Full suite green: 92 passed.